### PR TITLE
report to new relic the number of sockets open by the process

### DIFF
--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -4,6 +4,10 @@ package newrelic
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -37,6 +41,10 @@ func InitAgent(license, appName, hostName string, verbose bool) error {
 	agent.CollectHTTPStatuses = true
 	agent.Verbose = verbose
 
+	// Add custom metrics.
+	agent.AddCustomMetric(&openSocketsMetrica{})
+
+	// Start agent.
 	agent.Run()
 	return nil
 }
@@ -49,4 +57,42 @@ func Handler(c *gin.Context) {
 		agent.HTTPTimer.UpdateSince(startTime)
 		agent.HTTPStatusCounters[c.Writer.Status()].Inc(1)
 	}
+}
+
+// Our custom metrics go here.
+
+// openSocketsMetrica reports the number of open sockets by the current process.
+type openSocketsMetrica struct{}
+
+func (metrica *openSocketsMetrica) GetName() string {
+	return "network/openSockets"
+}
+
+func (metrica *openSocketsMetrica) GetUnits() string {
+	return "count"
+}
+
+func (metrica *openSocketsMetrica) GetValue() (float64, error) {
+	return float64(countOpenSockets()), nil
+}
+
+// countOpenSockets finds out the number of open sockets in the current process
+// using the system function lsof with some custom parameters:
+// -a: AND filters
+// -iTCP: select only TCP sockets
+// -n: inhibits the conversion of network numbers to host names, speeds up output
+// -P: nhibits the conversion of port numbers to port names, speeds up output
+// -p <PID>: outputs only for this process
+// -w: disables warnings
+func countOpenSockets() int {
+	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("lsof -a -iTCP -n -P -p %v -w | wc -l", os.Getpid())).Output()
+	if err != nil {
+		return 0
+	}
+	val := strings.TrimSpace(string(out))
+	num, err := strconv.Atoi(val)
+	if err != nil {
+		return 0
+	}
+	return num
 }


### PR DESCRIPTION
added a newrelic metrica that reports the number of open sockets open by the current process.

@oryband note: lsof stripped of some extra stuff, works very fast. Called once a minute, so no extra load.